### PR TITLE
use case insensitive emails

### DIFF
--- a/src/eba_db.ml
+++ b/src/eba_db.ml
@@ -107,7 +107,7 @@ let users_table =
 
 let emails_table =
   <:table< emails (
-       email text NOT NULL,
+       email citext NOT NULL,
        userid bigint NOT NULL
           ) >>
 
@@ -138,7 +138,7 @@ let user_groups_table =
 
 let preregister_table =
   <:table< preregister (
-       email text NOT NULL
+       email citext NOT NULL
           ) >>
 
 

--- a/template.distillery/PROJECT_NAME.sql
+++ b/template.distillery/PROJECT_NAME.sql
@@ -10,8 +10,11 @@ CREATE TABLE users ( -- DEFAULT
        avatar text
 );
 
+CREATE EXTENSION citext; --DEFAULT
+-- You may remove the above line if you use the type TEXT for emails instead of CITEXT
+
 CREATE TABLE emails ( -- DEFAULT
-       email text primary key, -- DEFAULT
+       email citext primary key, -- DEFAULT
        userid bigint NOT NULL references users(userid) -- DEFAULT
 );
 
@@ -33,5 +36,5 @@ CREATE TABLE user_groups ( -- DEFAULT
 );
 
 CREATE TABLE preregister (
-       email text NOT NULL
+       email citext NOT NULL
 );


### PR DESCRIPTION
Warning: There is no guarantee for emails to be case insensitive,
but case sensitivity on emails is particularly annoying and
email servers that implement case sensitivity are extremely rare.

This patch proposes to store the original email given by the user,
but not to distinguish `A@x.x` from `a@x.x` for any query in the
database.

modified:   src/eba_db.ml