### PR TITLE
allow attrs on tag html in Eba_page.content + discrimination of clien…

### DIFF
--- a/src/eba_page.eliom
+++ b/src/eba_page.eliom
@@ -26,13 +26,21 @@
 exception Predicate_failed of (exn option)
 
 type content =
-  {title: string option;
+  {html_attrs: Html_types.html_attrib Eliom_content.Html.attrib list;
+   title: string option;
    head : Html_types.head_content_fun elt list;
    body_attrs : Html_types.body_attrib Eliom_content.Html.attrib list;
    body : Html_types.body_content elt list}
 
-let content ?(a=[]) ?title ?(head = []) body =
-  { title;
+let content ?(html_a=[]) ?(a=[]) ?title ?(head = []) body =
+  let html_attrs =
+    if Eliom_client.is_client_app () then
+      a_class ["eba-client-app"] :: html_a
+    else
+      html_a
+  in
+  { html_attrs;
+    title;
     head = (head :> Html_types.head_content_fun elt list);
     body_attrs = a;
     body = (body :> Html_types.body_content elt list)}
@@ -124,7 +132,7 @@ module Make(C : PAGE) = struct
 
   let make_page_full content =
     let title = match content.title with Some t -> t | None -> C.title in
-    html
+    html ~a:content.html_attrs
       (Eliom_tools.F.head ~title ~css ~js
          ~other:(local_css @ local_js @ content.head @ C.other_head) ())
       (body ~a:content.body_attrs content.body)

--- a/src/eba_page.eliomi
+++ b/src/eba_page.eliomi
@@ -31,6 +31,7 @@ type content
 (** Specifies a page with an optional title, some optional extra
     metadata and a given body *)
 val content :
+  ?html_a: Html_types.html_attrib Eliom_content.Html.attrib list ->
   ?a : Html_types.body_attrib Eliom_content.Html.attrib list ->
   ?title : string ->
   ?head : [< Html_types.head_content_fun] Eliom_content.Html.elt list ->

--- a/src/eba_page.eliomi
+++ b/src/eba_page.eliomi
@@ -29,7 +29,8 @@ exception Predicate_failed of (exn option)
 type content
 
 (** Specifies a page with an optional title, some optional extra
-    metadata and a given body *)
+    metadata and a given body. [?html_a] allows to set attributes
+    to the html tag *)
 val content :
   ?html_a: Html_types.html_attrib Eliom_content.Html.attrib list ->
   ?a : Html_types.body_attrib Eliom_content.Html.attrib list ->


### PR DESCRIPTION
…t apps

(automatically add class eba-client-app to html node when Eliom_client.is_client_app ())

modified:   src/eba_page.eliom
modified:   src/eba_page.eliomi