### PR TITLE
DO NOT MERGE Trying to restart the app after connection

### DIFF
--- a/src/eba_handlers.eliomi
+++ b/src/eba_handlers.eliomi
@@ -1,7 +1,13 @@
+[%%server.start]
 
-[%%shared.start]
+val connect_handler : unit -> (string * string) * bool ->
+  Eliom_registration.browser_content Eliom_registration.kind Lwt.t
+
+[%%client.start]
 
 val connect_handler : unit -> (string * string) * bool -> unit Lwt.t
+
+[%%shared.start]
 
 val disconnect_handler : unit -> unit -> unit Lwt.t
 

--- a/template.distillery/PROJECT_NAME.eliom
+++ b/template.distillery/PROJECT_NAME.eliom
@@ -60,7 +60,7 @@ let () =
     ~service:Eba_services.sign_up_service'
     Eba_handlers.sign_up_handler;
 
-  Eliom_registration.Action.register
+  Eliom_registration.Any.register
     ~service:Eba_services.connect_service
     Eba_handlers.connect_handler;
 
@@ -101,6 +101,11 @@ let%client () =
     (%%%MODULE_NAME%%%_page.Opt.connected_page main_service_handler)
 
 
+let%client () =
+  (*VVV Unit.register *)
+  Eliom_registration.Action.register
+    ~service:Eba_services.connect_service
+    Eba_handlers.connect_handler
 
 
 


### PR DESCRIPTION
I'm trying to make the client app (mobile or not) restart when a user connects/disconnect.

Here is my current version that needs to be discussed.

 - I'd like to use Eliom_registration.Unit.register but it seems not implemented client side?
 - Is it possible to use Eliom_registration.Any for both sides in that case?
 - This version does not work well because there is also a restart triggered by Eba_comet.handle_message
May be it's enough to keep this (but the restart should probably be reimplemented for the mobile app, as we want to restart from eliom.html, not the current page). But anyway, i'd like to understand how to do that without this Eba_comet restart.

Also TODO: make possible to restart the app at any page (eliom.html + change_page_uri to the right URL ? ...) 

@vasilisp @vouillon any ideas?